### PR TITLE
Fix doc issues regarding scrolling and Auth header

### DIFF
--- a/docs/_includes/swagger.html
+++ b/docs/_includes/swagger.html
@@ -44,7 +44,7 @@
             setTimeout(function() {
               $('p').filter(function() {
                 return $(this).text() === 'Your webtask token';
-              }).html('Your webtask token. Navigate to <a style="cursor: pointer;" target="_blank" href="https://auth0.com/extend/try">extend/try</a> to get your token.');
+              }).html('Value should be \'Bearer: {your-token}\'. Navigate to <a style="cursor: pointer;" target="_blank" href="https://auth0.com/extend/try">extend/try</a> to get your token.');
             }, 200);
 
             $('.scrollspy')

--- a/docs/_sass/extend/_docs.scss
+++ b/docs/_sass/extend/_docs.scss
@@ -1,5 +1,6 @@
-body.prevent-scroll {
-  overflow: hidden;
+::-webkit-scrollbar {
+  width: 1px;
+  background: transparent;
 }
 
 .docs-content-container {


### PR DESCRIPTION
Fix for:

 - Scroll bars in side nav bar when "always on" in Mac os general settings -- reported by Geoff
 - The anchor tags on the side navigation break scrolling on the page. (Chrome windows + macOS) Need to refresh the page in order to regain scrolling.
 - In the HTTP API test fields, it wasn't too clear that the Authorization header needed 'Bearer ' prefixed before the token. Was getting 403s and couldn't figure out why for a while. (edited)


